### PR TITLE
Added Swift Summit London 2015

### DIFF
--- a/data/events.yml
+++ b/data/events.yml
@@ -22,6 +22,10 @@ MCE Conference 2015:
   url: http://2015.mceconf.com/
   date: Feb 4-6, 2015
   slug: mceconf-2015
+Swift Summit London 2015:
+  url: https://www.swiftsummit.com
+  date: March 21-22, 2015
+  slug: swift-summit-london-2015
 NSConference 2015:
   url: https://vimeo.com/nsconf
   date: March 16, 2015

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -126,8 +126,6 @@ Eric Allam:
   twitter: eallam
 Rachel Andrew:
   twitter: rachelandrew
-Sally Shepard:
-  twitter: mostgood
 Max Seelemann:
   twitter: macguru17
 David Rönnqvist:
@@ -196,6 +194,48 @@ Tim Oliver:
   twitter: timoliverau
 Marcus S. Zarra:
   twitter: mzarra
+Radek Pietruszewski:
+  twitter: radexp
+Gem Barrett:
+  twitter: gembarrett
+Hermés Piqué:
+  twitter: mostgood
+Alexsander Akers:
+  twitter: a2
+Jorge Izquierdo:
+  twitter: izqui9
+Marcin Krzyżanowski:
+  twitter: krzyzanowskim
+Anthony Levings:
+  twitter: sketchyTech
+Abizer Nazir:
+  twitter: abizern
+Jack Nutting:
+  twitter: jacknutting
+Kyle Fuller:
+  twitter: kylefuller
+Daniel Tomlinson:
+  twitter: dantoml
+Johannes Weiß:
+  twitter: johannesweiss
+Airspeed Velocity:
+  twitter: AirspeedSwift
+Ayaka Nonaka:
+  twitter: ayanonagon
+Colin Eberhardt:
+  twitter: ColinEberhardt
+Jan Riehn:
+  twitter: jriehn
+Carola Nitz:
+  twitter: _caro_n
+Joseph Lord:
+  twitter: jl_hfl
+Simon Gladman:
+  twitter: FlexMonkey
+Javier Soto:
+  twitter: javi
+Al Skipp:
+  twitter: al_skipp
 Jon Sterling:
   twitter: jonsterling
 Dave Lee:

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -218,6 +218,8 @@ Daniel Tomlinson:
   twitter: dantoml
 Johannes Weiß:
   twitter: johannesweiss
+Abizer Nasir:
+  twitter: abizern
 Airspeed Velocity:
   twitter: AirspeedSwift
 Ayaka Nonaka:

--- a/data/videos.yml
+++ b/data/videos.yml
@@ -345,6 +345,132 @@ NSConference 2015:
     speakers: [Daniel Kennett]
     title: "Dependable Salaries are for Chumps: Going Indie in 2015"
     vimeo: 124337772
+"Swift Summit London 2015":
+- language: English
+  speakers: [Radek Pietruszewski]
+  title: Swifty Methods
+  tags: []
+  youtube: QVvwiNbkUnI
+- language: English
+  speakers: [Gem Barrett]
+  title: View from the Other Side
+  tags: []
+  youtube: U67RA_uf58Y
+- language: English
+  speakers: [Hermés Piqué]
+  title: Closures in API Design
+  tags: []
+  youtube: 0SPwirqsugg
+- language: English
+  speakers: [Brian Gesiak]
+  title: Compelling Code
+  tags: []
+  youtube: 6PaSsskE2TM
+- language: English
+  speakers: [Daniel Steinberg]
+  title: (Functional) Programming for Everyone
+  tags: []
+  youtube: jiMxEEwEVPY
+- language: English
+  speakers: [Sally Shepard]
+  title: Extracurricular Swift
+  tags: []
+  youtube: EEovmqNvnkk
+- language: English
+  speakers: [Jorge Izquierdo]
+  title: "Taylor: The Most Un-Googleable Swift Library"
+  tags: []
+  youtube: T55C9lGEHMI
+- language: English
+  speakers: [Marcin Krzyżanowski]
+  title: "CryptoSwift: Cryptography You Can Do"
+  tags: []
+  youtube: VGDVA5KxVmk
+- language: English
+  speakers: [Boris Bügling]
+  title: Swift Funtime
+  tags: []
+  youtube: dDlEO53ZNTU
+- language: English
+  speakers: [Anthony Levings]
+  title: "JSON, Swift, and Type Safety: It's a wrap"
+  tags: []
+  youtube: W_GD5ilIxWE
+- language: English
+  speakers: [Abizer Nazir, Boris Bügling, Gem Barrett, Jack Nutting, Kyle Fuller, Radek Pietruszewski]
+  title: "Swift Panel: Where do we go from here?"
+  tags: []
+  youtube: faLLXWPqkqE
+- language: English
+  speakers: [Jack Nutting]
+  title: The Future Belongs to the Young
+  tags: []
+  youtube: A8eB2GO7cdg
+- language: English
+  speakers: [Daniel Tomlinson]
+  title: Swift, Meet Objective-C
+  tags: []
+  youtube: JlE5jZpZa_Q
+- language: English
+  speakers: [Chris Eidhof]
+  title: "Functional View Controllers: An Experiment"
+  tags: []
+  youtube: sXHJ-CeN0Us
+- language: English
+  speakers: [Johannes Weiß]
+  title: The Type System is Your Friend
+  tags: []
+  youtube: lcaawcLmtBA
+- language: English
+  speakers: [Abizer Nasir]
+  title: What Haskell Taught Me About Writing Swift
+  tags: []
+  youtube: paDHfVRpyCg
+- language: English
+  speakers: [Airspeed Velocity, Ayaka Nonaka, Brian Gesiak, Chris Eidhof, Colin Eberhardt]
+  title: Swift All-Star Panel
+  tags: []
+  youtube: ArV1bwTMAx0
+- language: English
+  speakers: [Jan Riehn]
+  title: Testing in Swift
+  tags: []
+  youtube: wLQpcVC5BMs
+- language: English
+  speakers: [Carola Nitz]
+  title: "Debugging in Swift: How Hard Can It Be?"
+  tags: []
+  youtube: z0x_5Za3tMA
+- language: English
+  speakers: [Joseph Lord]
+  title: How Swift is Swift?
+  tags: []
+  youtube: FjRqGSaQMKw
+- language: English
+  speakers: [Airspeed Velocity]
+  title: Zero-Cost Abstractions
+  tags: []
+  youtube: Gr6HXCQ9tX8
+- language: English
+  speakers: [Simon Gladman]
+  title: "The Supercomputer In Your Pocket: Metal & Swift"
+  tags: []
+  youtube: BCuUQUwgYcs
+- language: English
+  speakers: [Javier Soto]
+  title: Back to the Futures
+  tags: []
+  youtube: hPo0o2Z8gjE
+- language: English
+  speakers: [Colin Eberhardt]
+  title: "ReactiveCocoa and Swift: Better Together"
+  tags: []
+  youtube: 9-nICUaNBLA
+- language: English
+  speakers: [Al Skipp]
+  title: The Monad Among Us
+  tags: []
+  youtube: PZ_ShvesGIk
 UIKonf 2015:
   - language: English
     speakers: [JP Simard]


### PR DESCRIPTION
I've added the Swift Summit London 2015. I've also removed a duplicate speaker.

I think we also need a way to attach (or eventually directly link externally) slides. Many of the videos hosted and recorded by [Realm](https://realm.io/news/swift-summit/) have really important slides to fully understand the talk. I suggest to externally link directly to the Realm page but this would require some other changes in the linking code.

Thanks for the nice idea! 👏🏻
