### PR TITLE
Cache bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+cache: bundler
+


### PR DESCRIPTION
53 seconds is _way_ too long. 

See https://docs.travis-ci.com/user/caching/ for details about specifics.
