### PR TITLE
WWDC speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To add videos for an event:
 
 - Add the videos to `data/videos.yml`. Let's keep this yml file sorted by date. Also look at `data/events.yml` and `data/speakers.yml` and add the missing information there. Here's an [example PR](https://github.com/chriseidhof/ios-videos/pull/12). Please take the time to add tags, this really helps for discovering new videos.
 
-You might also want to run `bundle exec rake lint_speakers` to verify that every speaker has a bio.
+You might also want to run `bundle exec rake lint:speakers` to verify that every speaker has a bio. Run `bundle exec rake lint:events` to verify that every event has the correct info.
 
 If you want to import an entire YouTube account, you can run `bundle exec rake fetchyt[uikonf]` (replace `uikonf` with the name of the YouTube account). To do this, you need to create a `.env` file with a YouTube API account in there. You will need to edit the generated YAML before copy-pasting it into `videos.yml`.
 

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -379,29 +379,29 @@ Chris Lattner:
 Ken Orr:
   website: ""
 Mike Stern:
-  website: ""
+  twitter: themikestern
 Vipul Prakash:
-  website: ""
+  twitter: vipulved
 Jeffrey Traer Bernstein:
-  website: ""
+  twitter: trrraer
 Matthaeus Krenn:
-  website: ""
+  twitter: matthaeus
 Bill Lindmeier:
-  website: ""
+  twitter: wdlindmeier
 Brittany Paine:
   website: ""
 Debbie Sterling:
-  website: ""
+  twitter: debbieblox
 Antonio Cavedoni:
-  website: ""
+  twitter: verbosus
 Dave Abrahams:
   twitter: daveabrahams
 Todd Fernandez:
-  website: ""
+  twitter: trfm
 Dave Van Tassell:
-  website: ""
+  twitter: DaveVanTassell
 Trystan Kosmynka:
-  website: ""
+  twitter: tkosmynka
 Paul Turner:
   website: ""
 Sal Soghoian:
@@ -411,7 +411,7 @@ Ian Fisch:
 Ali Ozer:
   website: ""
 Shannon Tan:
-  website: ""
+  twitter: aleverns
 Qasid Sadiq:
   website: ""
 Peter Hajas:
@@ -421,17 +421,17 @@ Sumit Lonkar:
 Andrew Platzer:
   website: ""
 Nathan deVries:
-  website: ""
+  twitter: atnan
 Chloe Chang:
   website: ""
 Eliza Block:
   twitter: elizablock
 Paul Salzman:
-  website: ""
+  twitter: hipaulfi
 Anush Nadathur:
   website: ""
 Stefan Hafeneger:
-  website: ""
+  twitter: stefanhafeneger
 John Earl:
   website: ""
 Steve Lewallen:
@@ -449,7 +449,7 @@ Jesse Donaldson:
 Rishi Verma:
   website: ""
 Corbin Dunn:
-  website: ""
+  twitter: nibroc
 Sara Radi:
   website: ""
 Bruce Stadnyk:
@@ -459,45 +459,45 @@ Sophia Teutschler:
 Troy Stephens:
   website: ""
 Philippe Hausler:
-  website: ""
+  twitter: phausler
 Nat Hillard:
-  website: ""
+  twitter: NatHillard
 Jake Behrens:
   twitter: behrens
 Michael Turner:
-  website: ""
+  twitter: _mturner
 Ben Englert:
-  website: ""
+  twitter: bengl3rt
 Luke Hiesterman:
   website: ""
 Vince Spader:
   website: ""
 Peter Tsoi:
-  website: ""
+  twitter: peterctsoi
 Mike Hess:
   website: ""
 Ricky Mondello:
-  website: ""
+  twitter: rmondello
 Conrad Shultz:
-  website: ""
+  twitter: techconrad
 Jordan Rose:
   twitter: UINT_MIN
 Kate Stone:
-  website: ""
+  twitter: k8stone
 Woody Lidstone:
   website: ""
 Anders Bertelrud:
   website: ""
 Sam Page:
-  website: ""
+  twitter: sampage
 Connor Wakamo:
-  website: ""
+  twitter: cwakamo
 Matt Patenaude:
-  website: ""
+  twitter: mattpat
 Wil Turner:
   website: ""
 Kevin Cathey:
-  website: ""
+  twitter: kbcathey
 Nadav Rotem:
   twitter: nadavrot
 Michael Gottesman:
@@ -505,19 +505,19 @@ Michael Gottesman:
 Joe Grzywacz:
   website: ""
 Matt Moriarity:
-  website: ""
+  twitter: mjmoriarity
 Ted Kremenek:
   website: tkremenek
 Kris Markel:
-  website: ""
+  twitter: existopher
 Mike Swingler:
-  website: ""
+  twitter: swingler
 Doug Gregor:
   twitter: dgregor79
 Bill Dudney:
   website: bdudney
 Brent Fulgham:
-  website: ""
+  twitter: bfulgham
 Roger Pantos:
   website: ""
 Gianpaolo Fasoli:
@@ -527,7 +527,7 @@ Carol Teng:
 Shashank Phadke:
   website: ""
 Jono Wells:
-  website: ""
+  twitter: jonowells
 Tim Monroe:
   website: ""
 Akshatha Nagesh:
@@ -539,11 +539,11 @@ Doug Wyatt:
 David Hayward:
   website: ""
 Brian Weinstein:
-  website: ""
+  twitter: cleatsupkeep
 Nick Porcino:
-  website: ""
+  twitter: meshula
 Rav Dhiraj:
-  website: ""
+  twitter: mantadev
 Tim Oriol:
   website: ""
 Megan Gardner:
@@ -563,15 +563,15 @@ Phil Bennett:
 Danvin Ruangchan:
   website: ""
 Nick Shearer:
-  website: ""
+  twitter: nickjshearer
 Katie Skinner:
   website: ""
 Olivier Bonnet:
   website: ""
 Anil Kandangath:
-  website: ""
+  twitter: zimblyanil
 Ivan Krstic:
-  website: ""
+  twitter: radian
 Jon Andrews:
   website: ""
 Soren Spies:
@@ -590,7 +590,9 @@ Luke Case:
   website: ""
 Eric Bienville:
   website: ""
-Chris Jensen Alexander Ledwith:
+Chris Jensen:
+  website: ""
+Alexander Ledwith:
   website: ""
 Adam Driscoll:
   website: ""
@@ -601,17 +603,17 @@ Jamie Wood:
 Tommy Pauly:
   website: ""
 Anthony Chivetta:
-  website: ""
+  twitter: achivetta
 Daniel Steffen:
   website: ""
 Prabhakar Lakhera:
   website: ""
 Stuart Cheshire:
-  website: ""
+  twitter: stuartcheshire
 Michele Campeotto:
-  website: ""
+  twitter: micampe
 Julian Missig:
-  website: ""
+  twitter: jmissig
 Joe Malia:
   website: ""
 Marek Bereza:

--- a/data/videos.yml
+++ b/data/videos.yml
@@ -1634,7 +1634,7 @@ WWDC 2015:
     wwdc: "wwdc2015-712"
     direct-link: "http://devstreaming.apple.com/videos/wwdc/2015/7125ovmdf36/712/712_low_energy_high_performance_compression_and_accelerate.pdf?dl=1"
   - language: English
-    speakers: [Chris Jensen Alexander Ledwith]
+    speakers: [Chris Jensen, Alexander Ledwith]
     title: "Introducing Watch Connectivity"
     tags: [systemframeworks, watchos]
     wwdc: "wwdc2015-713"

--- a/source/_video_content.html.erb
+++ b/source/_video_content.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 </p>
 <% if video.wwdc %>
-  <p><%= link_to "Watch on apple.com", video['direct-link'] %></p>
+  <p><%= link_to "Watch on apple.com", video_url(video) %></p>
 <% else %>
   <div class="video-content">
     <p><%= embed_video video %></p>


### PR DESCRIPTION
Just added some more twitter handles for WWDC speakers 6916133, and clarify README info for rake lint 6f35d66

I've change the reference on `Watch on Apple.com` 8e6927e to link to _https://developer.apple.com/videos/play/wwdc2015-102_ instead of _http://devstreaming.apple.com/videos/wwdc/2015/1026npwuy2crj2xyuq11/102/102_platforms_state_of_the_union.pdf?dl=1_
