### PR TITLE
Add atom feeds for all video pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -69,18 +69,22 @@ set :js_dir, 'javascripts'
 set :images_dir, 'images'
 
 data.events.each do |name, metadata|
-  proxy "/events/#{metadata.slug}/index.html", "/event.html", :locals => { :name => name, :metadata => metadata , :videos => data.videos[name]}, :ignore => true
+  {'index.html': 'event.html', 'feed.xml': 'feed.xml'}.map do |page,template|
+    proxy "/events/#{metadata.slug}/#{page}", template, :locals => { :name => name, :metadata => metadata , :videos => data.videos[name]}, :ignore => true
+  end
 end
 
 data.speakers.each do |name, metadata|
   videos = data.videos.map { |k,v| [k,v.select { |video| video.speakers.include? name }] }.select { |k, v| v.count > 0 }
   proxy(speaker_page(name) + "/index.html", "/speaker.html", :locals => { :name => name, :speaker => metadata , :videos => videos}, :ignore => true)
+  proxy(speaker_page(name) + "/feed.xml", "feed.xml", :locals => { :name => name, :videos => videos.map { |c| c[1] }.flatten}, :ignore => true)
 end
 
 all_tags.each do |tag|
   videos = videos_for_tag(tag)
   slug = slug_for_tag(tag)
   proxy "/tags/#{slug}/index.html", "/tag.html", :locals => { :tag => tag, :videos => videos}, :ignore => true
+  proxy "/tags/#{slug}/feed.xml", "feed.xml", :locals => { :name => tag, :videos => videos.map { |c| c[1] }.flatten}, :ignore => true
 end
 
 # Build-specific configuration

--- a/config.rb
+++ b/config.rb
@@ -58,6 +58,10 @@ helpers TagHelpers
 
 ignore 'lib/*'
 
+# Used in atom feeds that need a full URL, avoid using otherwise 
+set :site_url, 'https://www.pomo.tv/'
+set :site_name, 'www.pomo.tv'
+
 set :css_dir, 'stylesheets'
 
 set :js_dir, 'javascripts'

--- a/config.rb
+++ b/config.rb
@@ -74,7 +74,7 @@ data.events.each do |name, metadata|
   feed = "#{base_url}/feed.xml"
 
   proxy html, "event.html", :locals => { :name => name, :metadata => metadata, :videos => data.videos[name], :atom_feed => feed}, :ignore => true
-  proxy feed, "feed.xml", :locals => { :name => name, :videos => data.videos[name], :html_page => html}, :ignore => true
+  proxy feed, "feed.xml", :locals => { :name => name, :videos => data.videos[name], :html_page => base_url}, :ignore => true
 end
 
 data.speakers.each do |name, metadata|
@@ -85,7 +85,7 @@ data.speakers.each do |name, metadata|
   videos = data.videos.map { |k,v| [k,v.select { |video| video.speakers.include? name }] }.select { |k, v| v.count > 0 }
 
   proxy html, "speaker.html", :locals => { :name => name, :speaker => metadata , :videos => videos, :atom_feed => feed}, :ignore => true
-  proxy feed, "feed.xml", :locals => { :name => name, :videos => videos.map { |c| c[1] }.flatten, :html_page => html}, :ignore => true
+  proxy feed, "feed.xml", :locals => { :name => name, :videos => videos.map { |c| c[1] }.flatten, :html_page => base_url}, :ignore => true
 end
 
 all_tags.each do |tag|
@@ -96,7 +96,7 @@ all_tags.each do |tag|
   videos = videos_for_tag(tag)
 
   proxy html, "tag.html", :locals => { :tag => tag, :videos => videos, :atom_feed => feed}, :ignore => true
-  proxy feed, "feed.xml", :locals => { :name => tag, :videos => videos.map { |c| c[1] }.flatten, :html_page => html}, :ignore => true
+  proxy feed, "feed.xml", :locals => { :name => tag, :videos => videos.map { |c| c[1] }.flatten, :html_page => base_url}, :ignore => true
 end
 
 # Build-specific configuration

--- a/source/_video_entry.xml.erb
+++ b/source/_video_entry.xml.erb
@@ -1,0 +1,14 @@
+  <entry>
+    <title><%= video.title %></title>
+    <link rel="alternate" href="<%= video_url(video) %>"/>
+    <id><%= video_url(video) %></id>
+    <updated><%= Time.now.utc.iso8601 %></updated>
+    <% video.speakers.each do |speaker| %>
+    <author>
+      <name><%= speaker %></name>
+    </author>
+    <% end %>
+    <content type="text/html">
+      <%=h partial :video_content, :locals => { :video => video } %>
+    </content>
+  </entry>

--- a/source/feed.xml.erb
+++ b/source/feed.xml.erb
@@ -1,0 +1,6 @@
+---
+layout: atom
+---
+<% videos.reverse.each do |video| %>
+  <%= partial :video_entry, :locals => { :video => video } %>
+<% end %>

--- a/source/layouts/atom.erb
+++ b/source/layouts/atom.erb
@@ -3,7 +3,7 @@
   <title><%= site_name %></title>
   <subtitle><%= current_page.data.name || name %></subtitle>
   <id><%= site_url %></id>
-  <link href="<%= site_url %>"/>
+  <link href="<%= site_url + (current_page.metadata[:locals][:html_page] || "") %>"/>
   <link href="<%= site_url + current_page.path %>" rel="self"/>
   <updated><%= Time.now.utc.iso8601 %></updated>
   <author>

--- a/source/layouts/atom.erb
+++ b/source/layouts/atom.erb
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title><%= site_name %></title>
+  <subtitle><%= current_page.data.name || name %></subtitle>
+  <id><%= site_url %></id>
+  <link href="<%= site_url %>"/>
+  <link href="<%= site_url + current_page.path %>" rel="self"/>
+  <updated><%= Time.now.utc.iso8601 %></updated>
+  <author>
+    <name><%= site_name %></name>
+  </author>
+ 
+  <%= yield %>
+
+</feed>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -11,8 +11,8 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= current_page.data.title || "pomo.tv" %></title>
 
-    <% if current_page.data.atom_feed %>
-    <link href="<%= current_page.data.atom_feed %>" type="application/atom+xml" rel="alternate" />
+    <% if current_page.data.atom_feed || current_page.metadata[:locals][:atom_feed] %>
+    <link href="<%= current_page.data.atom_feed || atom_feed %>" type="application/atom+xml" rel="alternate" />
     <% end %>
     
     <%= stylesheet_link_tag "normalize" %>

--- a/source/recent.xml.erb
+++ b/source/recent.xml.erb
@@ -1,35 +1,7 @@
 ---
-layout: false
-domain: www.pomo.tv
-url: https://www.pomo.tv/
+layout: atom
+name: Recently added videos
 ---
-<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title><%= current_page.data.domain %></title>
-  <subtitle>Recently added videos</subtitle>
-  <id><%= current_page.data.url %></id>
-  <link href="<%= current_page.data.url %>"/>
-  <link href="<%= current_page.data.url + current_page.path%>" rel="self"/>
-  <updated><%= Time.now.utc.iso8601 %></updated>
-  <author>
-    <name><%= current_page.data.domain %></name>
-  </author>
-
-  <% data.videos.values.flatten.reverse.take(25).each do |video| %>
-  <entry>
-    <title><%= video.title %></title>
-    <link rel="alternate" href="<%= video_url(video) %>"/>
-    <id><%= video_url(video) %></id>
-    <updated><%= Time.now.utc.iso8601 %></updated>
-    <% video.speakers.each do |speaker| %>
-    <author>
-      <name><%= speaker %></name>
-    </author>
-    <% end %>
-    <content type="text/html">
-      <%=h partial :video_content, :locals => { :video => video } %>
-    </content>
-  </entry>
-  <% end %>
-
-</feed>
+<% data.videos.values.flatten.reverse.take(25).each do |video| %>
+  <%= partial :video_entry, :locals => { :video => video } %>
+<% end %>


### PR DESCRIPTION
Implements #45.

This PR implements atom feeds for all pages, similar to the `recent.xml` feed but not limited (it will include all videos, just like the page does).

The feeds are not really discoverable currently (only included as alternate link).
