### PR TITLE
Easier import for WWDC

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,8 @@ require 'rubygems'
 require 'middleman-gh-pages'
 require 'dotenv/tasks'
 require 'yt'
-  require 'yaml'
+require 'yaml'
+
 
 task :default => [:build, "lint:speakers", "lint:events"]
 
@@ -15,6 +16,22 @@ task :fetchyt, [:user] => :dotenv do |t, args|
     puts "    title: #{video.title}"
     puts "    tags: []"
     puts "    youtube: #{video.id}"
+  end
+end
+
+task :fetchwwdc, [:year] => :dotenv do |t, args|
+  yaml_content = open("https://raw.githubusercontent.com/ASCIIwwdc/wwdc-session-transcripts/master/#{args[:year]}/_sessions.yml"){|f| f.read}
+  yaml_data = YAML::load(yaml_content) 
+  
+  # puts yaml_data.inspect
+  yaml_data.each do |id, video|
+    puts "  - language: English"
+    puts "    speakers: []"
+    puts "    title: \"#{video[:title]}\""
+    puts "    description: \"#{video[:description]}\""
+    puts "    tags: [#{video[:track]}]".downcase
+    puts "    wwdc: \"wwdc#{args[:year]}-#{id}\""
+    puts "    direct-link: \"https://developer.apple.com/videos/play/wwdc#{args[:year]}-#{id}\""
   end
 end
 

--- a/source/_video.html.erb
+++ b/source/_video.html.erb
@@ -2,6 +2,7 @@
     <header class="video-header">
         <h2 class="video-title"><%= video.title %></h2>
         <p class="video-meta">
+          <% if video.speakers.count > 0 %>
             By <% video.speakers.each do |s| %>
               <%= s %>
               <% if data.speakers[s] %>
@@ -11,6 +12,7 @@
                 - <%= link_to('@' + data.speakers[s].twitter, 'http://twitter.com/' + data.speakers[s].twitter) %><br/>
               <% end %>
             <% end %>
+          <% end %> 
         </p>
     </header>
     <%= partial :video_content, :locals => { :video => video } %>

--- a/source/_video_content.html.erb
+++ b/source/_video_content.html.erb
@@ -11,6 +11,9 @@
     No tags yet. <%= link_to "Suggest tags", github_repo_url %>
   <% end %>
 </p>
+<% if video['description'] %>
+  <p class="video-meta"> Description:<br/><%= video['description'] %></p>
+<% end %>
 <% if video.wwdc %>
   <p><%= link_to "Watch on apple.com", video_url(video) %></p>
 <% else %>

--- a/source/events/index.html.erb
+++ b/source/events/index.html.erb
@@ -7,7 +7,11 @@ title: Events
     <h2><%= link_to event, "/events/#{event_data.slug}" %></h2>
     <p>
       <% data.videos[event].each do |video| %>
-        <%= video.speakers.join(", ") %> - <%= link_to_video video %> <br/>
+      	<% if video.speakers.count > 0 %>
+      	  <%= video.speakers.join(", ") %> - <%= link_to_video video %> <br/>
+      	<% else %>
+      	  <%= link_to_video video %> <br/>
+      	<% end %>
       <% end %>
     </p>
   <% end %>


### PR DESCRIPTION
This needs approval since do not have speakers for the talks.
- The import has been done thanks to https://github.com/ASCIIwwdc/wwdc-session-transcripts.
- Description data has been added to `videos.yml`
- Events pages have been modified to look good without speakers.
