### PR TITLE
Live search

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -104,8 +104,16 @@ all_tags.each do |tag|
   proxy feed, "feed.xml", :locals => { :name => tag, :videos => videos.map { |c| c[1] }.flatten, :html_page => base_url}, :ignore => true
 end
 
+data.videos.map do |event,videos|
+    videos.map do |video|
+        video["event"] = event
+        page_url = "/videos/#{video_id(video)}.html"
+        proxy page_url, "video.html", :locals => { :video => video }, :ignore => true, :search_title => "Video: #{video.title}"
+    end
+end
+
 activate :search do |search|
-  search.resources = ['events/', 'tags/', 'speakers/']
+  search.resources = ['events/', 'tags/', 'speakers/', 'videos/']
   search.index_path = "search/index.json"
   search.fields = {
       search_title: {boost: 100, store: true, required: true},

--- a/source/javascripts/_search.js.erb
+++ b/source/javascripts/_search.js.erb
@@ -1,0 +1,86 @@
+//= require lunr.min
+
+var loadRequest = new XMLHttpRequest();
+
+var lunrIndex = null;
+var lunrData  = null;
+
+var searchField;
+
+function loadSearchIndex(callback) {
+  loadRequest.open("GET", "<%= search_index_path %>", true);
+  loadRequest.onreadystatechange = function () {
+    if (loadRequest.readyState !== XMLHttpRequest.DONE || loadRequest.status != 200) {
+      return;
+    } // else
+
+    lunrData = JSON.parse(loadRequest.responseText)
+    lunrIndex = lunr.Index.load(lunrData.index);
+    callback()
+  };
+  loadRequest.send();
+}
+
+function search(query, resultsId, stateId, limit) {
+  var resultsList = document.getElementById(resultsId);
+  var searchState = document.getElementById(stateId);
+  var hasMore = false;
+
+  // Clear state and current results
+  searchState.classList.remove("busy");
+  searchState.textContent = "";
+  resultsList.textContent = "";
+
+  // Perform the search, limit if needed 
+  var result = lunrIndex.search(query);
+  if (limit !== undefined) {
+    hasMore = result.length > limit;
+    result = result.splice(0, limit);
+  }
+
+  // Look up the docs
+  var docs = result.map(function(item) {
+      return lunrData.docs[item["ref"]]
+  });
+
+  // Show the results
+  docs.forEach(function(doc) {
+      var item = document.createElement("li");
+      var link = document.createElement("a");
+      link.textContent = doc["search_title"];
+      link.setAttribute("href", doc["url"]);
+      item.appendChild(link);
+      resultsList.appendChild(item);
+  });
+
+  // More results than shown?
+  if (hasMore) {
+      searchState.textContent = "Press enter to show all results…";
+  }
+
+  // No results?
+  if (query.length > 0 && docs.length == 0) {
+      searchState.textContent = "No results."
+  }
+}  
+
+window.addEventListener("load", function() {
+
+  searchField = document.getElementById("search-input-field");
+
+  searchField.addEventListener("input", function(event) {
+    if (lunrIndex == null) {
+      var searchState = document.getElementById("search-live-state");
+      searchState.classList.add("busy")
+    } else {
+      search(event.target.value, "search-live-results", "search-live-state", 10);
+    }
+  });
+
+}, false);
+
+loadSearchIndex(function() {
+  if (searchField !== undefined && searchField.value.length > 0) {
+     searchField.dispatchEvent(new Event("input"));
+  }
+});

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,2 +1,1 @@
-//= require lunr.min
 //= require_tree .

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -57,13 +57,22 @@
                     </li>
                 </ul>
             </nav>
-
-            <form action="/search" class="search-form pure-form">
-                <input name="q" type="search" placeholder="Search" />
-            </form>
-
-            <div id="search-live-results">
+            
+            <div class="pure-g search-live">
+              <div class="pure-u-1">
+                <form action="/search" class="search-form pure-form">
+                    <input id="search-input-field" name="q" type="search" placeholder="Search" />
+                </form>
+              </div>
+              <div class="pure-u-1">
+                <ol class="search-results" id="search-live-results"></ol>
+              </div>
+              <div class="pure-u-1">
+                <div id="search-live-state"></div>
+              </div>
             </div>
+          </div>
+
         </div>
     </div>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -33,9 +33,9 @@
   </head>
 
   <body class="<%= page_classes %>">
-    <div class="sidebar pure-u-1 pure-u-md-1-4">
+    <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
         <div class="header">
-            <h1 class="brand-title"><%= current_page.data.title || "pomo.tv" %></h1>
+            <h1 class="brand-title">pomo.tv</h1>
             <h2 class="brand-tagline">A collection of videos about Mac, iOS and Swift.</h2>
 
             <nav class="nav">
@@ -58,15 +58,20 @@
                 </ul>
             </nav>
 
+            <form action="/search" class="search-form pure-form">
+                <input name="q" type="search" placeholder="Search" />
+            </form>
+
+            <div id="search-live-results">
+            </div>
         </div>
     </div>
-  
-    <div class="content pure-u-1 pure-u-md-3-4">
-        <div class="search-container">
-            <form action="/search" class="search-form">
-                <input name="q" type="search" placeholder="Search" class="search-input" />
-            </form>
-        </div>
+
+    <div class="pure-u-1 pure-u-md-1-5">
+    </div>
+
+    <div class="content pure-u-1 pure-u-md-3-5">
+      <h1><%= current_page.data.title %></h1>
         <div>
           <%= yield %>
         </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -61,7 +61,7 @@
             <div class="pure-g search-live">
               <div class="pure-u-1">
                 <form action="/search" class="search-form pure-form">
-                    <input id="search-input-field" name="q" type="search" placeholder="Search" />
+                  <input id="search-input-field" name="q" type="search" placeholder="Search <%= data.videos.values.flatten.length %> videos…" />
                 </form>
               </div>
               <div class="pure-u-1">

--- a/source/lib/video_helpers.rb
+++ b/source/lib/video_helpers.rb
@@ -1,4 +1,15 @@
 module VideoHelpers
+  include Middleman::Blog::UriTemplates
+
+  def video_id(video)
+    template = uri_template "{event}-{speakers}-{title}"
+    safe_event = data.events[video.event].slug
+    safe_speakers = safe_parameterize video.speakers.sort.join(" ")
+    # Strip emoji and question marks from the titles
+    safe_title = safe_parameterize video.title.gsub(/[\?\u{1f300}-\u{1f5ff}\u{1f600}-\u{1f64f}]/, '-')
+    apply_uri_template template, {event: safe_event, speakers: safe_speakers, title: safe_title}
+  end
+
   def video_url(video)
     if video.wwdc
       "https://developer.apple.com/videos/play/#{video.wwdc}"

--- a/source/search/index.html.erb
+++ b/source/search/index.html.erb
@@ -7,55 +7,22 @@ title: Search
   <ol id='results'>
   </ol>
 </div>
-<div id="state" class="busy"></div>
+<div id="state"></div>
 
 <script type='text/javascript'>
-var lunrIndex = null;
-var lunrData  = null;
-
-function initialize(callback) {
-  var r = new XMLHttpRequest();
-  r.open("GET", "<%= search_index_path %>", true);
-  r.onreadystatechange = function () {
-    if (r.readyState != 4 || r.status != 200) return;
-    lunrData = JSON.parse(r.responseText)
-    lunrIndex = lunr.Index.load(lunrData.index);
-    callback()
-  };
-  r.send();
-}
-
-function append_result(title, url) {
-  var results_element = document.getElementById("results")
-  var item = document.createElement("li");
-  var link = document.createElement("a");
-  link.textContent = title;
-  link.setAttribute("href", url);
-  item.appendChild(link);
-  results_element.appendChild(item);
-}
-
-function search(query) {
-  var state = document.getElementById("state")
-  var result = lunrIndex.search(query);
-  var docs = result.map(function(item) {
-      return lunrData.docs[item["ref"]]
-  });
-  state.classList.remove("busy");
-  docs.forEach(function(doc) {
-      append_result(doc["search_title"], doc["url"])
-  });
-  if (docs.length == 0) {
-      state.textContent = "No results."
-  }
-}  
-
 // strip "?q="
 var query = document.location.search.substring(3);
-
 document.getElementById("query").appendChild(document.createTextNode(query));
 
-initialize(function() {
-   search(query);
-})
+function fullSearch() {
+  search(query, "results", "state")
+}
+
+if (loadRequest.readyState !== XMLHttpRequest.DONE) {
+  document.getElementById("state").classList.add("busy");
+  loadRequest.addEventListener("loadend", fullSearch);
+} else {
+  // Search now
+  fullSearch();
+}
 </script>

--- a/source/stylesheets/all.css
+++ b/source/stylesheets/all.css
@@ -214,28 +214,44 @@ input {
     }
 }
 
-/* SEARCH */
+/* LIVE SEARCH */
 
-.search-form input {
-  margin-top: 1em;
+.search-live {
   width: 50%;
   min-width: 30em;
+  margin: 1em auto 0em auto;
+}
+
+.search-form input {
+  width: 100%;
+}
+
+#search-live-state, #search-live-results {
+  text-align: left;
+}
+
+#search-live-results li {
+  background: rgb(80, 100, 110);
+  padding: 0.5em;
+  border-radius: 2px;
+}
+
+#search-live-results li a {
+  color: rgb(176, 202, 219);
 }
 
 /* SEARCH RESULTS */
 
-#results {
+#results, .search-results {
   list-style: inside decimal-leading-zero;
   padding-left: 0;
   color: #aaa;
 }
 
-#results li {
+#results li, .search-results li {
   margin-top: 0.5em;
 }
 
-#results li a {
+#results li a, .search-results li a {
   padding-left: 0.5em;
 }
-
-

--- a/source/stylesheets/all.css
+++ b/source/stylesheets/all.css
@@ -39,7 +39,7 @@ input {
     margin: 3em auto;
 }
 
-.sidebar {
+.pure-menu {
     background: rgb(61, 79, 93);
     color: #fff;
 }
@@ -174,24 +174,6 @@ input {
     background: none;
 }
 
-@media (min-width: 48em) {
-    .content {
-        padding: 2em 3em 0;
-        margin-left: 25%;
-    }
-
-    .header {
-        margin: 80% 2em 0;
-        text-align: right;
-    }
-
-    .sidebar {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-    }
-}
-
 /* BUSY/LOADING INDICATOR */
 
 .busy {
@@ -234,19 +216,10 @@ input {
 
 /* SEARCH */
 
-.search-container {
-    width:100%;
-}
-
-.search-input {
-    color: #666;
-    font-size: 2em;
-    width:100%;
-    border: 0;
-    outline: 0;
-    background: transparent;
-    border-bottom: 1px solid #999;
-    margin-bottom: 20px;
+.search-form input {
+  margin-top: 1em;
+  width: 50%;
+  min-width: 30em;
 }
 
 /* SEARCH RESULTS */

--- a/source/video.html.erb
+++ b/source/video.html.erb
@@ -12,6 +12,11 @@
               <% end %>
             <% end %>
         </p>
+        <% if video.event %>
+        <p class="video-meta">
+            At <%= link_to video.event, "/events/#{data.events[video.event].slug}" %>
+        </p>
+        <% end %>
     </header>
     <%= partial :video_content, :locals => { :video => video } %>
 </section>


### PR DESCRIPTION
Lot’s of changes in this pull request to enable live search:
- Added pages for each video. (Also see #58.) Please carefully review the way the video ID is created, since it would be best to keep this as stable as possible going forward.
- Changed the site layout. To have a nice big search bar on top, but also have it be part of the header (where the live search results will show up). I actually liked the sidebar, but this solves most of the issues I had with pulling the search bar out of the sidebar (see #62).
- And of course, added live search! It’s limited to the first 10 results but you can press enter to do a full search (go to the search page) and press escape to clear the search.

While the live search is a pretty cool thing to have, I don’t want to skip the discussion on how the make the video page URL and what the design for the site should be like (for now). So, let me know what you think! I’m happy to pull these changes out to separate pull requests first.
