### PR TITLE
CocoaHeads Stockholm 2015

### DIFF
--- a/data/events.yml
+++ b/data/events.yml
@@ -82,6 +82,10 @@ Swift Summit San Francisco 2015:
   url: https://www.swiftsummit.com
   date: October 29-30, 2015
   slug: swift-summit-san-francisco-2015
+CocoaHeads Stockholm 2015:
+  url: https://vimeo.com/cocoaheadssthlm
+  date: 2015
+  slug: cocoaheads-sthlm-2015
 Functional Swift Conference 2015:
   url: http://2015.funswiftconf.com
   date: December 12, 2015

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -848,3 +848,15 @@ Chris Espinosa:
   website: ""
 Howard Miller:
   website: ""
+Felix Krause:
+  twitter: KrauseFx
+Mohsan Khan:
+  website: ""
+Pedro Mancheno:
+  twitter: pedromancheno
+Anton Tingström:
+  website: ""
+Robin Enhorn:
+  twitter: Enhorn
+Nevyn Bengtsson:
+  twitter: nevyn

--- a/data/videos.yml
+++ b/data/videos.yml
@@ -2720,6 +2720,67 @@ iOS Conf Singapore:
     title: Building an Invisible App
     tags: []
     youtube: J0d97U8pKwI
+CocoaHeads Stockholm 2015:
+  - language: English
+    speakers: [Felix Krause]
+    title: Continuous Delivery with Fastlane
+    tags: [ci]
+    vimeo: 146505670
+    date: 2015-11-09
+  - language: English
+    speakers: [Florian Kugler]
+    title: Pragmatic Core Data
+    tags: [core data]
+    vimeo: 146505672
+    date: 2015-11-09
+  - language: English
+    speakers: [Mohsan Khan]
+    title: All you have to do is Hoppa!
+    tags: [games, sceneKit]
+    vimeo: 146505694
+    date: 2015-11-09
+  - language: English
+    speakers: [Pedro Mancheno]
+    title: Upgrading to watchOS 2
+    tags: [watchKit, watchOS]
+    vimeo: 142104528
+    date: 2015-10-05
+  - language: English
+    speakers: [Anton Tingström]
+    title: Introduction to tvOS
+    tags: [tvOS]
+    vimeo: 142104527
+    date: 2015-10-05
+  - language: English
+    speakers: [Robin Enhorn]
+    title: iPad PiP Video
+    tags: [pip]
+    vimeo: 138831846
+    date: 2015-09-07
+  - language: English
+    speakers: [David Rönnqvist]
+    title: Introduction to GameplayKit
+    tags: [GameplayKit]
+    vimeo: 136012905
+    date: 2015-08-10
+  - language: English
+    speakers: [Anton Tingström]
+    title: UI Testing In Practice
+    tags: [testing]
+    vimeo: 136014062
+    date: 2015-08-10
+  - language: English
+    speakers: [Nevyn Bengtsson]
+    title: Remote Works!
+    tags: [remote, tools]
+    vimeo: 118805668
+    date: 2015-02-02
+  - language: English
+    speakers: [Jack Nutting]
+    title: Technical Debt by the Book
+    tags: [management]
+    vimeo: 118839635
+    date: 2015-02-02
 Swift Summit San Francisco 2015:
   - language: English
     speakers: [JP Simard, Thomas Visser, Boris Bügling, Veronica Ray]


### PR DESCRIPTION
Added videos from various CocoaHeads Stockholm meetups during 2015. Felt like it didn't make sense to cut each meetup into its own event.
